### PR TITLE
Fix error when using Time.parse.

### DIFF
--- a/lib/artifactory.rb
+++ b/lib/artifactory.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+require 'time'
 require 'pathname'
 require 'artifactory/version'
 

--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+require 'time'
 require 'tempfile'
 
 module Artifactory


### PR DESCRIPTION
To use Time.parse should require 'time' otherwise if using this gem not in rails or other frameworks dont't contain the time automatically. The  statement `Time.parse instance.created` in from_hash method will not success and the time of the artifact object always be nil.
